### PR TITLE
Ignore cgroup metrics that do not exist

### DIFF
--- a/memlimit/cgroups.go
+++ b/memlimit/cgroups.go
@@ -30,7 +30,7 @@ func FromCgroupV1() (uint64, error) {
 		return 0, err
 	}
 
-	metrics, err := cg.Stat()
+	metrics, err := cg.Stat(cgroups.IgnoreNotExist)
 	if err != nil {
 		return 0, err
 	} else if metrics.Memory == nil {


### PR DESCRIPTION
When trying this package to get CgroupV1 limit of a pod deployed in AKS cluster, I got the following error:

`open /sys/fs/cgroup/memory/memory.memsw.usage_in_bytes: no such file or directory`

I did some investigation and found [this](memory.memsw.usage_in_bytes). It seems that for some system (most likely Ubuntu based, as is the case for my AKS cluster), memory swap may not be configured, and `memory.memsw.usage_in_bytes` metrics do not exist. But we don't need this metrics to calculate Cgroup limit. 

A simple fix as suggested by the above link is to add the `cgroups.IgnoreNotExist` error handler to the `cgroup.Stat` call. I have tried and confirmed that this works.