### PR TITLE
🫶 Add new SetGoMemLimitWithOptions

### DIFF
--- a/memlimit/memlimit.go
+++ b/memlimit/memlimit.go
@@ -57,6 +57,7 @@ func WithRatio(ratio float64) Option {
 }
 
 // WithEnv configure memory limit from environment variable.
+// By default `false`.
 func WithEnv() Option {
 	return Option(func(cfg *config) {
 		cfg.env = true

--- a/memlimit/memlimit.go
+++ b/memlimit/memlimit.go
@@ -57,9 +57,9 @@ func WithRatio(ratio float64) Option {
 }
 
 // WithEnv configure memory limit from environment variable.
-func WithEnv(flag bool) Option {
+func WithEnv() Option {
 	return Option(func(cfg *config) {
-		cfg.env = flag
+		cfg.env = true
 	})
 }
 


### PR DESCRIPTION
✅ Add configure options for `SetGoMemLimitWithEnv`:
+ WithLogger (https://github.com/KimMachineGun/automemlimit/issues/5);
+ WithProvider;
+ WithEnv;
+ WithRatio.

❗For example:
```go
logger, _ := zap.NewProduction()
sugar := logger.Sugar()

memlimit.SetGoMemLimitWithOptions(
   memlimit.WithLogger(sugar.Debugf), // default: `log.Printf`
   memlimit.WithProvider(memlimit.FromCgroupV1), // default: `memlimit.FromCgroup`
   memlimit.WithRatio(.8), // default: `0.9`
   memlimit.WithEnv(), // default: `false`
)
```

_P.S. I am confident that this commit will be beneficial for the community._