### PR TITLE
Fix 32-bit overflows of math.MaxInt64 constant

### DIFF
--- a/memlimit/memlimit_test.go
+++ b/memlimit/memlimit_test.go
@@ -267,7 +267,7 @@ func TestSetGoMemLimitWithOpts_WithRefreshInterval(t *testing.T) {
 
 	curr = debug.SetMemoryLimit(-1)
 	if curr != math.MaxInt64 {
-		t.Errorf("debug.SetMemoryLimit(-1) got = %v, want %v", curr, math.MaxInt64)
+		t.Errorf("debug.SetMemoryLimit(-1) got = %v, want %v", curr, int64(math.MaxInt64))
 	}
 
 	// 3. adjust limit
@@ -276,7 +276,7 @@ func TestSetGoMemLimitWithOpts_WithRefreshInterval(t *testing.T) {
 
 	curr = debug.SetMemoryLimit(-1)
 	if curr != math.MaxInt64-1024 {
-		t.Errorf("debug.SetMemoryLimit(-1) got = %v, want %v", curr, math.MaxInt64-1024)
+		t.Errorf("debug.SetMemoryLimit(-1) got = %v, want %v", curr, int64(math.MaxInt64)-1024)
 	}
 
 	// 4. no limit again
@@ -285,7 +285,7 @@ func TestSetGoMemLimitWithOpts_WithRefreshInterval(t *testing.T) {
 
 	curr = debug.SetMemoryLimit(-1)
 	if curr != math.MaxInt64 {
-		t.Errorf("debug.SetMemoryLimit(-1) got = %v, want %v", curr, math.MaxInt64)
+		t.Errorf("debug.SetMemoryLimit(-1) got = %v, want %v", curr, int64(math.MaxInt64))
 	}
 
 	// 5. new limit


### PR DESCRIPTION
math.MaxInt64 is an untyped int constant, the use of which will cause build failures on 32-bit archs if not explicitly typecast to int64.

This fixes a test build failure on 32-bit archs, e.g. "386":
```
$ GOARCH=386 go test -v -run TestSetGoMemLimitWithOpts ./...
?       github.com/KimMachineGun/automemlimit   [no test files]
# github.com/KimMachineGun/automemlimit/memlimit [github.com/KimMachineGun/automemlimit/memlimit.test]
memlimit/memlimit_test.go:270:64: cannot use math.MaxInt64 (untyped int constant 9223372036854775807) as int value in argument to t.Errorf (overflows)
memlimit/memlimit_test.go:279:64: cannot use math.MaxInt64 - 1024 (untyped int constant 9223372036854774783) as int value in argument to t.Errorf (overflows)
memlimit/memlimit_test.go:288:64: cannot use math.MaxInt64 (untyped int constant 9223372036854775807) as int value in argument to t.Errorf (overflows)
FAIL    github.com/KimMachineGun/automemlimit/memlimit [build failed]
FAIL
```